### PR TITLE
Remove GF(2⁸) assumption in lagrange_basis

### DIFF
--- a/src/share.ml
+++ b/src/share.ml
@@ -80,7 +80,7 @@ module Polynomial (F: Field) = struct
       (fun j u_j ->
          if i = j
          then F.one
-         else (u_j - x) / (u_j + u.(i)))
+         else (u_j - x) / (u_j - u.(i)))
       u
     |> product
 


### PR DESCRIPTION
Just a small fix for the generalization to any field. The usage of `(+)` instead of `(-)` is because that's what they did in the ietf draft.

In GF(2⁸), x - y = x + y.